### PR TITLE
Remove width from .resultado-imc

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -36,7 +36,6 @@
 .seuImc {font-size: 2rem;}
 .resultado-imc {
     color: #A8DADC;
-    width: 30%;
     height: 4rem;
     font-size: 3rem;
 }


### PR DESCRIPTION
Projeto bacana, irmão!
Notei que quando a tela fica menor que 330px, o conteúdo de .resultado-imc (l37) começa a pular pra fora. Removendo o width no DevTools percebi que ele responde melhor à largura da tela.